### PR TITLE
Fix image convert for Python 3

### DIFF
--- a/tools/convert.py
+++ b/tools/convert.py
@@ -30,7 +30,7 @@ frames = []
 image = Image.open(sys.argv[1])
 n_frames, width, height = image.n_frames if hasattr(image, 'n_frames') else 1, image.width, image.height
 
-used_frames = min((n_frames - start_at_frame) / skip_frames, lim_frames)
+used_frames = min((n_frames - start_at_frame) // skip_frames, lim_frames)
 used_width = min(length_x, image.width)
 used_height = min(length_y, image.height)
 
@@ -53,4 +53,4 @@ else:
     print('rgb.gif([0x' +
           ', 0x'.join([', 0x'.join([format(r << 24 | g << 16 | b << 8 | a, '08x') for r, g, b, a in frame]) for frame in
                        frames]) +
-          '], %d, %d, %d, %d, %d)' % (0, 0, used_width, used_height, used_frames))
+          '], (%d, %d), (%d, %d), %d)' % (0, 0, used_width, used_height, used_frames))

--- a/tools/convert.py
+++ b/tools/convert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import sys
 from PIL import Image


### PR DESCRIPTION
Seems the code is intended for Python 2, which has been EOL for while now.

This should fix stuff for Python3 (tested with gif and png)